### PR TITLE
Add IAsyncExecutor abstraction for improved testability

### DIFF
--- a/src/Infrastructure/App.AsyncExecutor.pas
+++ b/src/Infrastructure/App.AsyncExecutor.pas
@@ -1,0 +1,309 @@
+{*******************************************************}
+{                                                       }
+{       Bluetooth Quick Connect                         }
+{       Async Executor Interface and Implementations    }
+{                                                       }
+{       Provides abstraction for async operations to    }
+{       enable testability and reduce code duplication. }
+{                                                       }
+{       Design Principles:                              }
+{       - DIP: High-level modules depend on abstraction }
+{       - ISP: Focused interface for async execution    }
+{       - OCP: New executors via interface impl         }
+{       - Testability: Inject synchronous for tests     }
+{                                                       }
+{*******************************************************}
+
+unit App.AsyncExecutor;
+
+interface
+
+uses
+  System.SysUtils,
+  System.Classes;
+
+type
+  /// <summary>
+  /// Procedure type for work to be executed asynchronously.
+  /// </summary>
+  TAsyncWorkProc = TProc;
+
+  /// <summary>
+  /// Procedure type for callback after async work completes.
+  /// Always called on the main thread.
+  /// </summary>
+  TAsyncCallbackProc = TProc;
+
+  /// <summary>
+  /// Procedure type for error callback.
+  /// </summary>
+  TAsyncErrorProc = reference to procedure(const AException: Exception);
+
+  /// <summary>
+  /// Interface for executing work asynchronously.
+  /// Abstracts thread creation to enable testability.
+  ///
+  /// Usage in production: Inject TThreadPoolExecutor
+  /// Usage in tests: Inject TSynchronousExecutor for deterministic behavior
+  /// </summary>
+  IAsyncExecutor = interface
+    ['{E8F6C9A1-2B4D-4E8F-A1C3-5D7E9F0B2A4C}']
+
+    /// <summary>
+    /// Executes work on a background thread.
+    /// Fire-and-forget pattern.
+    /// </summary>
+    /// <param name="AWork">The work to execute.</param>
+    procedure Execute(AWork: TAsyncWorkProc);
+
+    /// <summary>
+    /// Executes work on a background thread, then executes callback on main thread.
+    /// </summary>
+    /// <param name="AWork">The work to execute on background thread.</param>
+    /// <param name="AOnComplete">Callback to execute on main thread after work completes.</param>
+    procedure ExecuteWithCallback(AWork: TAsyncWorkProc; AOnComplete: TAsyncCallbackProc);
+
+    /// <summary>
+    /// Executes work on a background thread with error handling.
+    /// Callback is called on main thread; error handler on main thread if exception occurs.
+    /// </summary>
+    /// <param name="AWork">The work to execute on background thread.</param>
+    /// <param name="AOnComplete">Callback to execute on main thread after success.</param>
+    /// <param name="AOnError">Error handler to execute on main thread if exception occurs.</param>
+    procedure ExecuteWithErrorHandler(AWork: TAsyncWorkProc;
+      AOnComplete: TAsyncCallbackProc; AOnError: TAsyncErrorProc);
+  end;
+
+  /// <summary>
+  /// Production implementation using anonymous threads.
+  /// Creates a new thread for each work item.
+  /// </summary>
+  TThreadPoolExecutor = class(TInterfacedObject, IAsyncExecutor)
+  public
+    procedure Execute(AWork: TAsyncWorkProc);
+    procedure ExecuteWithCallback(AWork: TAsyncWorkProc; AOnComplete: TAsyncCallbackProc);
+    procedure ExecuteWithErrorHandler(AWork: TAsyncWorkProc;
+      AOnComplete: TAsyncCallbackProc; AOnError: TAsyncErrorProc);
+  end;
+
+  /// <summary>
+  /// Test implementation that executes work synchronously.
+  /// All work is executed immediately on the calling thread.
+  /// Enables deterministic unit testing without threading.
+  /// </summary>
+  TSynchronousExecutor = class(TInterfacedObject, IAsyncExecutor)
+  private
+    FLastException: Exception;
+    FExecuteCount: Integer;
+  public
+    constructor Create;
+
+    procedure Execute(AWork: TAsyncWorkProc);
+    procedure ExecuteWithCallback(AWork: TAsyncWorkProc; AOnComplete: TAsyncCallbackProc);
+    procedure ExecuteWithErrorHandler(AWork: TAsyncWorkProc;
+      AOnComplete: TAsyncCallbackProc; AOnError: TAsyncErrorProc);
+
+    /// <summary>
+    /// Number of times Execute was called (for test verification).
+    /// </summary>
+    property ExecuteCount: Integer read FExecuteCount;
+
+    /// <summary>
+    /// Last exception that occurred during execution (for test verification).
+    /// </summary>
+    property LastException: Exception read FLastException;
+  end;
+
+/// <summary>
+/// Creates a production async executor.
+/// Factory function for dependency injection.
+/// </summary>
+function CreateAsyncExecutor: IAsyncExecutor;
+
+/// <summary>
+/// Creates a test (synchronous) async executor.
+/// Factory function for dependency injection in tests.
+/// </summary>
+function CreateSynchronousExecutor: IAsyncExecutor;
+
+implementation
+
+uses
+  App.Logger;
+
+const
+  LOG_SOURCE = 'AsyncExecutor';
+
+{ TThreadPoolExecutor }
+
+procedure TThreadPoolExecutor.Execute(AWork: TAsyncWorkProc);
+begin
+  if not Assigned(AWork) then
+    Exit;
+
+  TThread.CreateAnonymousThread(
+    procedure
+    begin
+      try
+        AWork();
+      except
+        on E: Exception do
+          LogError('Execute: Unhandled exception: %s', [E.Message], LOG_SOURCE);
+      end;
+    end
+  ).Start;
+end;
+
+procedure TThreadPoolExecutor.ExecuteWithCallback(AWork: TAsyncWorkProc;
+  AOnComplete: TAsyncCallbackProc);
+var
+  LOnComplete: TAsyncCallbackProc;
+begin
+  if not Assigned(AWork) then
+  begin
+    if Assigned(AOnComplete) then
+      TThread.Queue(nil, AOnComplete);
+    Exit;
+  end;
+
+  LOnComplete := AOnComplete;
+
+  TThread.CreateAnonymousThread(
+    procedure
+    begin
+      try
+        AWork();
+        if Assigned(LOnComplete) then
+          TThread.Queue(nil, LOnComplete);
+      except
+        on E: Exception do
+          LogError('ExecuteWithCallback: Unhandled exception: %s', [E.Message], LOG_SOURCE);
+      end;
+    end
+  ).Start;
+end;
+
+procedure TThreadPoolExecutor.ExecuteWithErrorHandler(AWork: TAsyncWorkProc;
+  AOnComplete: TAsyncCallbackProc; AOnError: TAsyncErrorProc);
+var
+  LOnComplete: TAsyncCallbackProc;
+  LOnError: TAsyncErrorProc;
+begin
+  if not Assigned(AWork) then
+  begin
+    if Assigned(AOnComplete) then
+      TThread.Queue(nil, AOnComplete);
+    Exit;
+  end;
+
+  LOnComplete := AOnComplete;
+  LOnError := AOnError;
+
+  TThread.CreateAnonymousThread(
+    procedure
+    begin
+      try
+        AWork();
+        if Assigned(LOnComplete) then
+          TThread.Queue(nil, LOnComplete);
+      except
+        on E: Exception do
+        begin
+          LogError('ExecuteWithErrorHandler: Exception: %s', [E.Message], LOG_SOURCE);
+          if Assigned(LOnError) then
+          begin
+            // Capture exception for main thread
+            var LException := E;
+            TThread.Queue(nil,
+              procedure
+              begin
+                LOnError(LException);
+              end
+            );
+          end;
+        end;
+      end;
+    end
+  ).Start;
+end;
+
+{ TSynchronousExecutor }
+
+constructor TSynchronousExecutor.Create;
+begin
+  inherited Create;
+  FExecuteCount := 0;
+  FLastException := nil;
+end;
+
+procedure TSynchronousExecutor.Execute(AWork: TAsyncWorkProc);
+begin
+  Inc(FExecuteCount);
+
+  if not Assigned(AWork) then
+    Exit;
+
+  try
+    AWork();
+  except
+    on E: Exception do
+    begin
+      FLastException := E;
+      LogError('Execute (sync): Exception: %s', [E.Message], LOG_SOURCE);
+    end;
+  end;
+end;
+
+procedure TSynchronousExecutor.ExecuteWithCallback(AWork: TAsyncWorkProc;
+  AOnComplete: TAsyncCallbackProc);
+begin
+  Inc(FExecuteCount);
+
+  try
+    if Assigned(AWork) then
+      AWork();
+    if Assigned(AOnComplete) then
+      AOnComplete();
+  except
+    on E: Exception do
+    begin
+      FLastException := E;
+      LogError('ExecuteWithCallback (sync): Exception: %s', [E.Message], LOG_SOURCE);
+    end;
+  end;
+end;
+
+procedure TSynchronousExecutor.ExecuteWithErrorHandler(AWork: TAsyncWorkProc;
+  AOnComplete: TAsyncCallbackProc; AOnError: TAsyncErrorProc);
+begin
+  Inc(FExecuteCount);
+
+  try
+    if Assigned(AWork) then
+      AWork();
+    if Assigned(AOnComplete) then
+      AOnComplete();
+  except
+    on E: Exception do
+    begin
+      FLastException := E;
+      LogError('ExecuteWithErrorHandler (sync): Exception: %s', [E.Message], LOG_SOURCE);
+      if Assigned(AOnError) then
+        AOnError(E);
+    end;
+  end;
+end;
+
+{ Factory Functions }
+
+function CreateAsyncExecutor: IAsyncExecutor;
+begin
+  Result := TThreadPoolExecutor.Create;
+end;
+
+function CreateSynchronousExecutor: IAsyncExecutor;
+begin
+  Result := TSynchronousExecutor.Create;
+end;
+
+end.

--- a/tests/Tests.AsyncExecutor.pas
+++ b/tests/Tests.AsyncExecutor.pas
@@ -1,0 +1,306 @@
+{*******************************************************}
+{                                                       }
+{       Bluetooth Quick Connect - Tests                 }
+{       Async Executor Unit Tests                       }
+{                                                       }
+{       Tests for IAsyncExecutor implementations.       }
+{                                                       }
+{*******************************************************}
+
+unit Tests.AsyncExecutor;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.SysUtils,
+  System.Classes,
+  App.AsyncExecutor;
+
+type
+  [TestFixture]
+  TSynchronousExecutorTests = class
+  private
+    FExecutor: TSynchronousExecutor;
+    FWorkExecuted: Boolean;
+    FCallbackExecuted: Boolean;
+    FErrorHandled: Boolean;
+    FLastError: Exception;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure Execute_RunsWorkImmediately;
+
+    [Test]
+    procedure Execute_IncrementsExecuteCount;
+
+    [Test]
+    procedure Execute_NilWork_DoesNotRaise;
+
+    [Test]
+    procedure ExecuteWithCallback_RunsWorkAndCallback;
+
+    [Test]
+    procedure ExecuteWithCallback_NilWork_RunsCallbackOnly;
+
+    [Test]
+    procedure ExecuteWithCallback_NilCallback_RunsWorkOnly;
+
+    [Test]
+    procedure ExecuteWithErrorHandler_OnSuccess_RunsCallback;
+
+    [Test]
+    procedure ExecuteWithErrorHandler_OnError_RunsErrorHandler;
+
+    [Test]
+    procedure ExecuteWithErrorHandler_SetsLastException;
+
+    [Test]
+    procedure ExecuteCount_TracksAllCalls;
+  end;
+
+  [TestFixture]
+  TThreadPoolExecutorTests = class
+  private
+    FExecutor: IAsyncExecutor;
+  public
+    [Setup]
+    procedure Setup;
+
+    [Test]
+    procedure Execute_NilWork_DoesNotRaise;
+
+    [Test]
+    procedure ExecuteWithCallback_NilWork_DoesNotRaise;
+  end;
+
+  [TestFixture]
+  TFactoryFunctionTests = class
+  public
+    [Test]
+    procedure CreateAsyncExecutor_ReturnsThreadPoolExecutor;
+
+    [Test]
+    procedure CreateSynchronousExecutor_ReturnsSynchronousExecutor;
+  end;
+
+implementation
+
+{ TSynchronousExecutorTests }
+
+procedure TSynchronousExecutorTests.Setup;
+begin
+  FExecutor := TSynchronousExecutor.Create;
+  FWorkExecuted := False;
+  FCallbackExecuted := False;
+  FErrorHandled := False;
+  FLastError := nil;
+end;
+
+procedure TSynchronousExecutorTests.TearDown;
+begin
+  FExecutor.Free;
+end;
+
+procedure TSynchronousExecutorTests.Execute_RunsWorkImmediately;
+begin
+  FExecutor.Execute(
+    procedure
+    begin
+      FWorkExecuted := True;
+    end
+  );
+
+  Assert.IsTrue(FWorkExecuted, 'Work should be executed immediately');
+end;
+
+procedure TSynchronousExecutorTests.Execute_IncrementsExecuteCount;
+begin
+  Assert.AreEqual(0, FExecutor.ExecuteCount, 'Initial count should be 0');
+
+  FExecutor.Execute(procedure begin end);
+
+  Assert.AreEqual(1, FExecutor.ExecuteCount, 'Count should be 1 after Execute');
+end;
+
+procedure TSynchronousExecutorTests.Execute_NilWork_DoesNotRaise;
+begin
+  // Should not raise any exception
+  FExecutor.Execute(nil);
+
+  Assert.AreEqual(1, FExecutor.ExecuteCount, 'Count should increment even for nil');
+end;
+
+procedure TSynchronousExecutorTests.ExecuteWithCallback_RunsWorkAndCallback;
+begin
+  FExecutor.ExecuteWithCallback(
+    procedure
+    begin
+      FWorkExecuted := True;
+    end,
+    procedure
+    begin
+      FCallbackExecuted := True;
+    end
+  );
+
+  Assert.IsTrue(FWorkExecuted, 'Work should be executed');
+  Assert.IsTrue(FCallbackExecuted, 'Callback should be executed');
+end;
+
+procedure TSynchronousExecutorTests.ExecuteWithCallback_NilWork_RunsCallbackOnly;
+begin
+  FExecutor.ExecuteWithCallback(
+    nil,
+    procedure
+    begin
+      FCallbackExecuted := True;
+    end
+  );
+
+  Assert.IsFalse(FWorkExecuted, 'Work should not be executed (was nil)');
+  Assert.IsTrue(FCallbackExecuted, 'Callback should be executed');
+end;
+
+procedure TSynchronousExecutorTests.ExecuteWithCallback_NilCallback_RunsWorkOnly;
+begin
+  FExecutor.ExecuteWithCallback(
+    procedure
+    begin
+      FWorkExecuted := True;
+    end,
+    nil
+  );
+
+  Assert.IsTrue(FWorkExecuted, 'Work should be executed');
+  // No exception should occur for nil callback
+  Assert.Pass('Nil callback handled correctly');
+end;
+
+procedure TSynchronousExecutorTests.ExecuteWithErrorHandler_OnSuccess_RunsCallback;
+begin
+  FExecutor.ExecuteWithErrorHandler(
+    procedure
+    begin
+      FWorkExecuted := True;
+    end,
+    procedure
+    begin
+      FCallbackExecuted := True;
+    end,
+    procedure(const E: Exception)
+    begin
+      FErrorHandled := True;
+    end
+  );
+
+  Assert.IsTrue(FWorkExecuted, 'Work should be executed');
+  Assert.IsTrue(FCallbackExecuted, 'Callback should be executed on success');
+  Assert.IsFalse(FErrorHandled, 'Error handler should not be called on success');
+end;
+
+procedure TSynchronousExecutorTests.ExecuteWithErrorHandler_OnError_RunsErrorHandler;
+begin
+  FExecutor.ExecuteWithErrorHandler(
+    procedure
+    begin
+      raise Exception.Create('Test error');
+    end,
+    procedure
+    begin
+      FCallbackExecuted := True;
+    end,
+    procedure(const E: Exception)
+    begin
+      FErrorHandled := True;
+      FLastError := E;
+    end
+  );
+
+  Assert.IsFalse(FCallbackExecuted, 'Callback should not be called on error');
+  Assert.IsTrue(FErrorHandled, 'Error handler should be called');
+  Assert.IsNotNull(FLastError, 'Error should be captured');
+  Assert.AreEqual('Test error', FLastError.Message, 'Error message should match');
+end;
+
+procedure TSynchronousExecutorTests.ExecuteWithErrorHandler_SetsLastException;
+begin
+  FExecutor.ExecuteWithErrorHandler(
+    procedure
+    begin
+      raise Exception.Create('Test exception');
+    end,
+    nil,
+    nil
+  );
+
+  Assert.IsNotNull(FExecutor.LastException, 'LastException should be set');
+  Assert.AreEqual('Test exception', FExecutor.LastException.Message);
+end;
+
+procedure TSynchronousExecutorTests.ExecuteCount_TracksAllCalls;
+begin
+  FExecutor.Execute(procedure begin end);
+  FExecutor.ExecuteWithCallback(procedure begin end, nil);
+  FExecutor.ExecuteWithErrorHandler(procedure begin end, nil, nil);
+
+  Assert.AreEqual(3, FExecutor.ExecuteCount, 'All three calls should be tracked');
+end;
+
+{ TThreadPoolExecutorTests }
+
+procedure TThreadPoolExecutorTests.Setup;
+begin
+  FExecutor := CreateAsyncExecutor;
+end;
+
+procedure TThreadPoolExecutorTests.Execute_NilWork_DoesNotRaise;
+begin
+  // Should not raise any exception
+  FExecutor.Execute(nil);
+
+  Assert.Pass('Nil work handled correctly');
+end;
+
+procedure TThreadPoolExecutorTests.ExecuteWithCallback_NilWork_DoesNotRaise;
+begin
+  // Should not raise any exception
+  FExecutor.ExecuteWithCallback(nil, nil);
+
+  Assert.Pass('Nil work and callback handled correctly');
+end;
+
+{ TFactoryFunctionTests }
+
+procedure TFactoryFunctionTests.CreateAsyncExecutor_ReturnsThreadPoolExecutor;
+var
+  Executor: IAsyncExecutor;
+begin
+  Executor := CreateAsyncExecutor;
+
+  Assert.IsNotNull(Executor, 'Executor should not be nil');
+  // Verify it's the production implementation by checking type
+  Assert.IsTrue(Executor is TThreadPoolExecutor, 'Should return TThreadPoolExecutor');
+end;
+
+procedure TFactoryFunctionTests.CreateSynchronousExecutor_ReturnsSynchronousExecutor;
+var
+  Executor: IAsyncExecutor;
+begin
+  Executor := CreateSynchronousExecutor;
+
+  Assert.IsNotNull(Executor, 'Executor should not be nil');
+  // Verify it's the test implementation by checking type
+  Assert.IsTrue(Executor is TSynchronousExecutor, 'Should return TSynchronousExecutor');
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TSynchronousExecutorTests);
+  TDUnitX.RegisterTestFixture(TThreadPoolExecutorTests);
+  TDUnitX.RegisterTestFixture(TFactoryFunctionTests);
+
+end.


### PR DESCRIPTION
Testability/DIP Improvement: Introduces IAsyncExecutor interface to abstract async thread execution, enabling deterministic unit testing of async operations in TMainPresenter.

Problem:
- Direct TThread.CreateAnonymousThread usage in presenter
- Cannot unit test async logic without actual threads
- Duplicated thread creation and error handling patterns
- Violates Dependency Inversion Principle

Solution:
- Create App.AsyncExecutor unit with IAsyncExecutor interface
- Implement TThreadPoolExecutor for production use
- Implement TSynchronousExecutor for test use
- Inject executor into TMainPresenter

New Types:
- IAsyncExecutor: Interface for async execution abstraction
  - Execute: Fire-and-forget async work
  - ExecuteWithCallback: Async work with main-thread callback
  - ExecuteWithErrorHandler: Async work with error handling
- TThreadPoolExecutor: Production impl using anonymous threads
- TSynchronousExecutor: Test impl that runs synchronously
  - ExecuteCount property for test verification
  - LastException property for error verification

Changes to TMainPresenter:
- Add FAsyncExecutor field with DI via constructor
- Optional parameter defaults to TThreadPoolExecutor
- ConnectDeviceAsync: Uses FAsyncExecutor.Execute
- ToggleConnectionAsync: Uses FAsyncExecutor.Execute
- SetRadioStateAsync: Uses FAsyncExecutor.ExecuteWithCallback

Test Coverage:
- TSynchronousExecutorTests: 10 tests
  - Execute, ExecuteWithCallback, ExecuteWithErrorHandler
  - Nil handling, error handling, count tracking
- TThreadPoolExecutorTests: Nil handling
- TFactoryFunctionTests: Factory returns correct types

SOLID/GRASP:
- DIP: Presenter depends on IAsyncExecutor abstraction
- ISP: Focused interface for async execution only
- OCP: New executor types via interface implementation
- Information Expert: Executor knows about threading